### PR TITLE
Add kaldi-python-io==1.0.0 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ scipy==1.2.1
 tqdm==4.31.1
 torch==1.0.1.post2
 numpy==1.16.2
+kaldi-python-io==1.0.0


### PR DESCRIPTION
The kaldi-python-io package is necessary to train the model.